### PR TITLE
ci: remove pipefail from check_version

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,12 +34,12 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: ./.github/actions/setup-algokit-python
+      - name: Setup Python and algokit
+        uses: ./.github/actions/setup-algokit-python
 
       - name: Check if version is already released
         id: check_version
         run: |
-          set -o pipefail
           poetry run semantic-release --strict --noop version
           rc=$?
           echo "return_code=$rc" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release:
-    name: Release Library
+    name: Semantic Release
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -34,7 +34,8 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup-algokit-python
+      - name: Setup Python and algokit
+        uses: ./.github/actions/setup-algokit-python
 
       - name: pytest + coverage
         shell: bash


### PR DESCRIPTION
## Proposed Changes

- Removes `set -o pipefail` from check_version step so the job doesn't fail