### PR TITLE
Fix: correct shared-config repo URL in CI workflows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python and algokit
-        uses: algorandfoundation/shared-config/.github/actions/setup-algokit-python@main
+        uses: algorandfoundation/algokit-shared-config/.github/actions/setup-algokit-python@main
 
       - name: Run tests and quality checks
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   python-ci:
-    uses: algorandfoundation/shared-config/.github/workflows/python-ci.yaml@main
+    uses: algorandfoundation/algokit-shared-config/.github/workflows/python-ci.yaml@main


### PR DESCRIPTION
## Summary
Fixed incorrect GitHub repo reference from `algorandfoundation/shared-config` to `algorandfoundation/algokit-shared-config` in both `pr.yaml` and `cd.yaml` workflows.

## Changes
- `pr.yaml`: fixed reusable workflow URL for `python-ci.yaml`
- `cd.yaml`: fixed composite action URL for `setup-algokit-python`

## Dependencies
- ~**Blocked by:** [algorandfoundation/shared-config#12](https://github.com/algorandfoundation/algokit-shared-config/pull/12) (must be merged to `main` first)~