### PR TITLE
Fix: add v prefix to python-semantic-release action tag

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Python Semantic Release - Alpha
         id: release-alpha
         if: steps.get_branch.outputs.branch == 'alpha' && !inputs.production_release
-        uses: python-semantic-release/python-semantic-release@10.5.3
+        uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           prerelease: true
@@ -70,7 +70,7 @@ jobs:
       - name: Python Semantic Release - Beta (non-prod)
         id: release-beta
         if: steps.get_branch.outputs.branch == 'main' && !inputs.production_release
-        uses: python-semantic-release/python-semantic-release@10.5.3
+        uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           prerelease: true
@@ -78,7 +78,7 @@ jobs:
       - name: Python Semantic Release - Production
         id: release-prod
         if: steps.get_branch.outputs.branch == 'main' && inputs.production_release
-        uses: python-semantic-release/python-semantic-release@10.5.3
+        uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary
The python-semantic-release/python-semantic-release action was referenced as @10.5.3 but GitHub Actions requires the v prefix (@v10.5.3) to resolve the tag.