### PR TITLE
docs: add examples

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -60,6 +60,10 @@ export default defineConfig({
           ],
         },
         {
+          label: "Examples",
+          items: [{ label: "Overview", link: "/examples/" }],
+        },
+        {
           label: "API Reference",
           collapsed: true,
           items: [

--- a/docs/src/components/DescriptionRenderer.astro
+++ b/docs/src/components/DescriptionRenderer.astro
@@ -1,0 +1,46 @@
+---
+interface Props {
+  text: string
+}
+
+const { text } = Astro.props
+
+const lines = text.split('\n')
+
+type Element = { tag: 'p'; content: string } | { tag: 'ul'; items: string[] }
+const elements: Element[] = []
+let bulletBuffer: string[] = []
+
+const flushBullets = () => {
+  if (bulletBuffer.length > 0) {
+    elements.push({ tag: 'ul', items: [...bulletBuffer] })
+    bulletBuffer = []
+  }
+}
+
+for (const line of lines) {
+  const trimmed = line.trim()
+  if (!trimmed) continue
+  if (/^[-•]\s/.test(trimmed)) {
+    bulletBuffer.push(trimmed.replace(/^[-•]\s*/, ''))
+  } else {
+    flushBullets()
+    elements.push({ tag: 'p', content: trimmed })
+  }
+}
+flushBullets()
+---
+
+{
+  elements.map((el) =>
+    el.tag === 'ul' ? (
+      <ul>
+        {el.items.map((item) => (
+          <li set:html={item} />
+        ))}
+      </ul>
+    ) : (
+      <p set:html={el.content} />
+    ),
+  )
+}

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,21 @@
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
+import { examplesLoader } from "./loaders/examples-loader";
 
 export const collections = {
   docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  examples: defineCollection({
+    loader: examplesLoader(),
+    schema: z.object({
+      id: z.string(),
+      title: z.string(),
+      description: z.string(),
+      prerequisites: z.string(),
+      code: z.string(),
+      order: z.number(),
+      filename: z.string(),
+      runCommand: z.string(),
+    }),
+  }),
 };

--- a/docs/src/loaders/examples-loader.ts
+++ b/docs/src/loaders/examples-loader.ts
@@ -1,0 +1,143 @@
+import type { Loader } from 'astro/loaders'
+import fs from 'node:fs'
+import path from 'node:path'
+
+type ExampleEntry = {
+  id: string
+  title: string
+  description: string
+  prerequisites: string
+  code: string
+  order: number
+  filename: string
+  runCommand: string
+}
+
+function lineSeparator(text: string, isBullet: boolean, lastWasBullet: boolean): string {
+  if (!text) return ''
+  if (isBullet || lastWasBullet) return '\n'
+  return ' '
+}
+
+function parseDocstring(content: string): { title: string; description: string; prerequisites: string } {
+  const docstringMatch = content.match(/"""([\s\S]*?)"""/)
+
+  if (!docstringMatch) {
+    return { title: 'Example', description: '', prerequisites: '' }
+  }
+
+  const docstringContent = docstringMatch[1]
+
+  // Extract title from "Example NN: Title" or "Example: Title" line
+  const titleMatch = docstringContent.match(/Example\s*\d*:\s*(.+)/)
+  const title = titleMatch?.[1]?.trim() || 'Example'
+
+  const lines = docstringContent.split('\n').map((line) => line.trim())
+
+  let description = ''
+  let prerequisites = ''
+  let inPrerequisites = false
+  let lastLineWasBullet = false
+
+  for (const line of lines) {
+    if (line.startsWith('Example')) continue
+
+    if (line.toLowerCase().startsWith('prerequisites:') || line.toLowerCase() === 'prerequisites') {
+      inPrerequisites = true
+      lastLineWasBullet = false
+      const prereqContent = line.replace(/prerequisites:?\s*/i, '').trim()
+      if (prereqContent) prerequisites = prereqContent
+      continue
+    }
+
+    if (!line) {
+      lastLineWasBullet = false
+      if (inPrerequisites) {
+        if (prerequisites) prerequisites += '\n'
+      } else if (description) {
+        description += '\n'
+      }
+      continue
+    }
+
+    const isBullet = line.startsWith('-') || line.startsWith('•')
+    if (inPrerequisites) {
+      prerequisites += lineSeparator(prerequisites, isBullet, lastLineWasBullet) + line
+    } else {
+      description += lineSeparator(description, isBullet, lastLineWasBullet) + line
+    }
+    lastLineWasBullet = isBullet
+  }
+
+  return {
+    title,
+    description: description.trim(),
+    prerequisites: prerequisites.trim() || 'LocalNet running (`algokit localnet start`)',
+  }
+}
+
+/**
+ * Extract order number from filename (e.g., "01_example.py" -> 1)
+ */
+function extractOrder(filename: string): number {
+  const match = filename.match(/^(\d+)_/)
+  return match ? parseInt(match[1], 10) : 999
+}
+
+function createSlug(filename: string): string {
+  return filename.replace(/\.py$/, '').replace(/_/g, '-')
+}
+
+export function examplesLoader(): Loader {
+  return {
+    name: 'examples-loader',
+    load: async ({ store, logger }) => {
+      const examplesDir = path.resolve(process.cwd(), '..', 'examples', 'subscriber')
+
+      logger.info(`Loading examples from ${examplesDir}`)
+
+      if (!fs.existsSync(examplesDir)) {
+        logger.error(`Examples directory not found: ${examplesDir}`)
+        return
+      }
+
+      const entries: ExampleEntry[] = []
+
+      const files = fs.readdirSync(examplesDir).filter((f) => f.endsWith('.py') && !f.startsWith('_'))
+
+      for (const filename of files) {
+        const filePath = path.join(examplesDir, filename)
+        const content = fs.readFileSync(filePath, 'utf-8')
+        const { title, description, prerequisites } = parseDocstring(content)
+        const order = extractOrder(filename)
+        const slug = createSlug(filename)
+
+        const entry: ExampleEntry = {
+          id: slug,
+          title,
+          description,
+          prerequisites,
+          code: content,
+          order,
+          filename,
+          runCommand: `uv run python ${filename}`,
+        }
+
+        entries.push(entry)
+      }
+
+      entries.sort((a, b) => a.order - b.order)
+
+      logger.info(`Found ${entries.length} examples`)
+
+      for (const entry of entries) {
+        store.set({
+          id: entry.id,
+          data: entry,
+        })
+      }
+    },
+  }
+}
+
+export type { ExampleEntry }

--- a/docs/src/pages/examples/[...slug].astro
+++ b/docs/src/pages/examples/[...slug].astro
@@ -1,0 +1,79 @@
+---
+import { getCollection } from 'astro:content'
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro'
+import { Code } from '@astrojs/starlight/components'
+import DescriptionRenderer from '../../components/DescriptionRenderer.astro'
+
+export async function getStaticPaths() {
+  const examples = await getCollection('examples')
+  return examples.map((example) => ({
+    params: { slug: example.id },
+    props: { example },
+  }))
+}
+
+const { example } = Astro.props
+const { title, description, prerequisites, code, filename, runCommand } = example.data
+
+// Get all examples for sidebar navigation
+const allExamples = await getCollection('examples')
+const sortedExamples = allExamples.sort((a, b) => a.data.order - b.data.order)
+
+// GitHub source URL
+const githubUrl = `https://github.com/algorandfoundation/algokit-subscriber-py/blob/main/examples/subscriber/${filename}`
+---
+
+<StarlightPage
+  frontmatter={{
+    title: title,
+    description: description,
+  }}
+  headings={[
+    { depth: 2, text: 'Description', slug: 'description' },
+    { depth: 2, text: 'Prerequisites', slug: 'prerequisites' },
+    { depth: 2, text: 'Run This Example', slug: 'run-this-example' },
+    { depth: 2, text: 'Code', slug: 'code' },
+  ]}
+>
+  <p><a href="/algokit-subscriber-py/examples/">&larr; Back to Examples</a></p>
+
+  <h2 id="description">Description</h2>
+  <DescriptionRenderer text={description || 'This example demonstrates usage of the AlgoKit Subscriber Python library.'} />
+
+  <h2 id="prerequisites">Prerequisites</h2>
+  <ul>
+    {
+      prerequisites.split('\n').map((prereq) => {
+        const text = prereq.replace(/^[-•]\s*/, '').trim()
+        return text ? <li set:html={text} /> : null
+      })
+    }
+  </ul>
+
+  <h2 id="run-this-example">Run This Example</h2>
+  <p>From the <code>examples/subscriber</code> directory:</p>
+  <Code code={runCommand} lang="bash" />
+
+  <h2 id="code">Code</h2>
+  <p>
+    <a href={githubUrl} target="_blank" rel="noopener noreferrer">View source on GitHub &rarr;</a>
+  </p>
+  <Code code={code} lang="python" title={filename} />
+
+  <hr />
+
+  <h3>All Examples</h3>
+  <ul>
+    {
+      sortedExamples.map((e) => (
+        <li>
+          {e.id === example.id ? (
+            <strong>{e.data.title}</strong>
+          ) : (
+            <a href={`/algokit-subscriber-py/examples/${e.id}/`}>{e.data.title}</a>
+          )}
+        </li>
+      ))
+    }
+  </ul>
+</StarlightPage>

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from 'astro:content'
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro'
+import DescriptionRenderer from '../../components/DescriptionRenderer.astro'
+
+const allExamples = await getCollection('examples')
+const sortedExamples = allExamples.sort((a, b) => a.data.order - b.data.order)
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Code Examples',
+    description: `${allExamples.length} runnable Python examples demonstrating AlgoKit Subscriber features`,
+  }}
+>
+  <p>
+    Browse <strong>{allExamples.length}</strong> runnable Python examples demonstrating how to use the AlgoKit
+    Subscriber library. Each example is self-contained and progressively introduces features.
+  </p>
+
+  <h2>Quick Start</h2>
+  <pre><code>{`# Clone the repository
+git clone https://github.com/algorandfoundation/algokit-subscriber-py.git
+cd algokit-subscriber-py/examples/subscriber
+
+# Install dependencies
+uv sync
+
+# Run any example
+uv run python 01_basic_poll_once.py`}</code></pre>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li>Python &gt;= 3.12</li>
+    <li><a href="https://docs.astral.sh/uv/">uv</a> package manager installed</li>
+    <li>
+      <a href="https://github.com/algorandfoundation/algokit-cli">AlgoKit CLI</a> installed
+    </li>
+    <li>
+      LocalNet running (<code>algokit localnet start</code>)
+    </li>
+  </ul>
+
+  <h2>Examples ({allExamples.length})</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Example</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        sortedExamples.map((example) => (
+          <tr>
+            <td>
+              <a href={`/algokit-subscriber-py/examples/${example.id}/`}>{example.data.title}</a>
+            </td>
+            <td><DescriptionRenderer text={example.data.description || ''} /></td>
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</StarlightPage>

--- a/examples/subscriber/uv.lock
+++ b/examples/subscriber/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "algokit-subscriber"
-version = "2.0.0a2"
+version = "2.0.0a3"
 source = { editable = "../../" }
 dependencies = [
     { name = "algokit-utils" },
@@ -15,9 +15,7 @@ requires-dist = [{ name = "algokit-utils", specifier = ">=5.0.0a15" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "furo", specifier = ">=2024.1.29" },
     { name = "mypy", specifier = ">=1.19.1" },
-    { name = "myst-parser", specifier = ">=4.0.0" },
     { name = "pip-audit", specifier = ">=2.9.0" },
     { name = "poethepoet", specifier = ">=0.36.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
@@ -26,12 +24,13 @@ dev = [
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "python-semantic-release", specifier = ">=10.5.3" },
     { name = "ruff", specifier = ">=0.12.9" },
-    { name = "sphinx", specifier = ">=8.2.3" },
-    { name = "sphinx-autobuild", specifier = ">=2024.4.16" },
-    { name = "sphinx-autodoc2", specifier = ">=0.5.0" },
-    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
-    { name = "sphinx-mermaid", specifier = ">=0.0.8" },
     { name = "syrupy", specifier = ">=5.0.0" },
+]
+docs = [
+    { name = "pydoclint", specifier = ">=0.6.0,<0.7" },
+    { name = "sphinx", specifier = ">=8.0.0,<9" },
+    { name = "sphinx-autoapi", specifier = ">=3.4.0,<4" },
+    { name = "sphinx-markdown-builder", specifier = ">=0.6.8,<0.7" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "algokit-subscriber"
-version = "2.0.0a2"
+version = "2.0.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "algokit-utils" },


### PR DESCRIPTION
Integrates the 15 runnable subscriber examples into the Starlight documentation site

<img width="1436" height="917" alt="image" src="https://github.com/user-attachments/assets/d4b80da5-5239-4119-8ab8-93de7e952f14" />
